### PR TITLE
비관적 락 적용에서 낙관적 락으로 변경 및 동시성 테스트 && (코칭시간때 보여주셨던 레이어 구조 적용))

### DIFF
--- a/src/main/java/com/hhpluslecture/lecture/aggregate/domain/Lecture.java
+++ b/src/main/java/com/hhpluslecture/lecture/aggregate/domain/Lecture.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 public class Lecture {
     private long id;
     private String title;
-    private int version;
     private int headCount;
     private int capacity;
     private LocalDateTime startAt;

--- a/src/main/java/com/hhpluslecture/lecture/aggregate/domain/Lecture.java
+++ b/src/main/java/com/hhpluslecture/lecture/aggregate/domain/Lecture.java
@@ -1,0 +1,50 @@
+package com.hhpluslecture.lecture.aggregate.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Lecture {
+    private long id;
+    private String title;
+    private int version;
+    private int headCount;
+    private int capacity;
+    private LocalDateTime startAt;
+    private LocalDateTime createAt;
+
+    public Lecture(String title, int capacity, LocalDateTime startAt) {
+        //
+        this.title = title;
+        this.capacity = capacity;
+        this.startAt = startAt;
+        this.createAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+    }
+
+    public void apply() {
+        this.headCount++;
+    }
+
+    public boolean isCapacityExceeded() {
+        //
+        return getHeadCount() == this.capacity;
+    }
+
+    public boolean isEnrollmentStarted() {
+        //
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        return this.startAt.isBefore(now);
+    }
+}

--- a/src/main/java/com/hhpluslecture/lecture/aggregate/entity/LectureEntity.java
+++ b/src/main/java/com/hhpluslecture/lecture/aggregate/entity/LectureEntity.java
@@ -1,0 +1,29 @@
+package com.hhpluslecture.lecture.aggregate.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "lecture")
+@AllArgsConstructor
+@NoArgsConstructor
+public class LectureEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private String title;
+    @Version
+    private int version;
+    private int headCount;
+    private int capacity;
+
+    private LocalDateTime startAt;
+    private LocalDateTime createAt;
+}

--- a/src/main/java/com/hhpluslecture/lecture/aggregate/entity/LectureEntity.java
+++ b/src/main/java/com/hhpluslecture/lecture/aggregate/entity/LectureEntity.java
@@ -19,8 +19,6 @@ public class LectureEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
     private String title;
-    @Version
-    private int version;
     private int headCount;
     private int capacity;
 

--- a/src/main/java/com/hhpluslecture/lecture/controller/LectureController.java
+++ b/src/main/java/com/hhpluslecture/lecture/controller/LectureController.java
@@ -1,0 +1,48 @@
+package com.hhpluslecture.lecture.controller;
+
+import com.hhpluslecture.lecture.aggregate.command.ApplyLectureCommand;
+import com.hhpluslecture.lecture.aggregate.command.RegisterLectureCommand;
+import com.hhpluslecture.lecture.aggregate.dto.LectureInfo;
+import com.hhpluslecture.lecture.service.LectureService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/lectures")
+@RequiredArgsConstructor
+public class LectureController {
+    //
+    private final LectureService lectureService;
+
+    @PostMapping
+    public ResponseEntity<Long> createLecture(@RequestBody RegisterLectureCommand registerLectureCommand) {
+        registerLectureCommand.validate();
+        String title = registerLectureCommand.getTitle();
+        int capacity = registerLectureCommand.getCapacity();
+        LocalDateTime startAt = registerLectureCommand.getStartAt();
+        return ResponseEntity.ok(this.lectureService.createLecture(title, capacity, startAt));
+    }
+
+    @PostMapping("/apply")
+    public void apply(@RequestBody ApplyLectureCommand command) {
+        long lectureId = command.getLectureId();
+        String userId = command.getUserId();
+        lectureService.applyLecture(lectureId, userId);
+    }
+
+    @GetMapping()
+    public ResponseEntity<List<LectureInfo>> loadLectureList(@RequestParam(required = false) String userId) {
+        //
+        return ResponseEntity.ok(LectureInfo.fromDomains(lectureService.loadLectures(userId)));
+    }
+
+    @GetMapping("/application/{userId}")
+    public ResponseEntity<Boolean> isApplyComplete(@PathVariable String userId, @RequestParam long lectureId) {
+        //
+        return ResponseEntity.ok(lectureService.isApplyComplete(lectureId, userId));
+    }
+}

--- a/src/main/java/com/hhpluslecture/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/hhpluslecture/lecture/repository/LectureRepository.java
@@ -1,0 +1,12 @@
+package com.hhpluslecture.lecture.repository;
+
+import com.hhpluslecture.lecture.aggregate.entity.LectureEntity;
+
+import java.util.List;
+
+public interface LectureRepository {
+    long create(LectureEntity lectureEntity);
+    void update(LectureEntity lectureEntity);
+    LectureEntity findById(long id);
+    List<LectureEntity> findAll();
+}

--- a/src/main/java/com/hhpluslecture/lecture/repository/LectureRepository.java
+++ b/src/main/java/com/hhpluslecture/lecture/repository/LectureRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 public interface LectureRepository {
     long create(LectureEntity lectureEntity);
     void update(LectureEntity lectureEntity);
+    LectureEntity findByIdForUpdate(long id);
     LectureEntity findById(long id);
     List<LectureEntity> findAll();
 }

--- a/src/main/java/com/hhpluslecture/lecture/repository/impl/LectureRepositoryImpl.java
+++ b/src/main/java/com/hhpluslecture/lecture/repository/impl/LectureRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.hhpluslecture.lecture.repository.impl;
+
+import com.hhpluslecture.lecture.aggregate.entity.LectureEntity;
+import com.hhpluslecture.lecture.repository.LectureRepository;
+import com.hhpluslecture.lecture.repository.orm.LectureJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class LectureRepositoryImpl implements LectureRepository {
+    //
+    private final LectureJpaRepository lectureJpaRepository;
+
+    @Override
+    public long create(LectureEntity lectureEntity) {
+        //
+        lectureJpaRepository.save(lectureEntity);
+        return lectureEntity.getId();
+    }
+
+    @Override
+    public void update(LectureEntity lectureEntity) {
+        lectureJpaRepository.save(lectureEntity);
+    }
+
+    @Override
+    public LectureEntity findById(long id) {
+        Optional<LectureEntity> res =  lectureJpaRepository.findById(id);
+        if(res.isEmpty())
+            throw new NoSuchElementException("Lecture with id " + id + " not found");
+        return res.get();
+    }
+
+    @Override
+    public List<LectureEntity> findAll() {
+        return lectureJpaRepository.findAllByOrderByStartAtAsc();
+    }
+}

--- a/src/main/java/com/hhpluslecture/lecture/repository/impl/LectureRepositoryImpl.java
+++ b/src/main/java/com/hhpluslecture/lecture/repository/impl/LectureRepositoryImpl.java
@@ -29,6 +29,14 @@ public class LectureRepositoryImpl implements LectureRepository {
     }
 
     @Override
+    public LectureEntity findByIdForUpdate(long id) {
+        Optional<LectureEntity> res =  lectureJpaRepository.findByIdForUpdate(id);
+        if(res.isEmpty())
+            throw new NoSuchElementException("Lecture with id " + id + " not found");
+        return res.get();
+    }
+
+    @Override
     public LectureEntity findById(long id) {
         Optional<LectureEntity> res =  lectureJpaRepository.findById(id);
         if(res.isEmpty())

--- a/src/main/java/com/hhpluslecture/lecture/repository/orm/LectureJpaRepository.java
+++ b/src/main/java/com/hhpluslecture/lecture/repository/orm/LectureJpaRepository.java
@@ -1,0 +1,15 @@
+package com.hhpluslecture.lecture.repository.orm;
+
+
+import com.hhpluslecture.lecture.aggregate.entity.LectureEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+
+public interface LectureJpaRepository extends JpaRepository<LectureEntity, Long> {
+    //
+    Optional<LectureEntity> findById(long id);
+    List<LectureEntity> findAllByOrderByStartAtAsc();
+}

--- a/src/main/java/com/hhpluslecture/lecture/repository/orm/LectureJpaRepository.java
+++ b/src/main/java/com/hhpluslecture/lecture/repository/orm/LectureJpaRepository.java
@@ -2,7 +2,10 @@ package com.hhpluslecture.lecture.repository.orm;
 
 
 import com.hhpluslecture.lecture.aggregate.entity.LectureEntity;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,6 +13,9 @@ import java.util.Optional;
 
 public interface LectureJpaRepository extends JpaRepository<LectureEntity, Long> {
     //
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select l from LectureEntity l where l.id = :id")
+    Optional<LectureEntity> findByIdForUpdate(long id);
     Optional<LectureEntity> findById(long id);
     List<LectureEntity> findAllByOrderByStartAtAsc();
 }

--- a/src/main/java/com/hhpluslecture/lecture/service/LectureService.java
+++ b/src/main/java/com/hhpluslecture/lecture/service/LectureService.java
@@ -1,0 +1,14 @@
+package com.hhpluslecture.lecture.service;
+
+import com.hhpluslecture.lecture.aggregate.domain.Lecture;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface LectureService {
+    long createLecture(String title, int capacity, LocalDateTime startAt);
+    void applyLecture(long lectureId, String userId);
+    boolean isApplyComplete(long lectureId, String userId);
+    Lecture loadLecture(long lectureId);
+    List<Lecture> loadLectures(String userId);
+}

--- a/src/main/java/com/hhpluslecture/lecture/service/impl/LectureServiceImpl.java
+++ b/src/main/java/com/hhpluslecture/lecture/service/impl/LectureServiceImpl.java
@@ -41,7 +41,7 @@ public class LectureServiceImpl implements LectureService {
     @Override
     @Transactional
     public void applyLecture(long lectureId, String userId) {
-        Lecture lecture = LectureMapper.convertToDomain(lectureRepository.findById(lectureId));
+        Lecture lecture = LectureMapper.convertToDomain(lectureRepository.findByIdForUpdate(lectureId));
         if(lecture == null)
             throw new NoSuchElementException("해당 강의가 존재하지 않습니다.");
         if(!lecture.isEnrollmentStarted())

--- a/src/main/java/com/hhpluslecture/lecture/service/impl/LectureServiceImpl.java
+++ b/src/main/java/com/hhpluslecture/lecture/service/impl/LectureServiceImpl.java
@@ -1,0 +1,100 @@
+package com.hhpluslecture.lecture.service.impl;
+
+import com.hhpluslecture.lecture.aggregate.domain.Lecture;
+import com.hhpluslecture.lectureApplication.aggregate.domain.LectureApplication;
+import com.hhpluslecture.lectureApplication.repository.LectureApplicationRepository;
+import com.hhpluslecture.lecture.repository.LectureRepository;
+import com.hhpluslecture.lecture.service.LectureService;
+import com.hhpluslecture.lecture.service.error.CapacityExceededException;
+import com.hhpluslecture.lecture.service.error.RegistrationNotOpenException;
+import com.hhpluslecture.lecture.service.mapper.LectureMapper;
+import com.hhpluslecture.lectureApplication.service.mapper.LectureApplicationMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.logging.log4j.util.Strings;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LectureServiceImpl implements LectureService {
+    //
+    private final LectureRepository lectureRepository;
+    private final LectureApplicationRepository lectureApplicationRepository;
+
+
+    @Override
+    @Transactional
+    public long createLecture(String title, int capacity, LocalDateTime startAt) {
+        Lecture lecture = new Lecture(title, capacity, startAt);
+        return this.lectureRepository.create(LectureMapper.convertToEntity(lecture));
+    }
+
+    @Override
+    @Transactional
+    public void applyLecture(long lectureId, String userId) {
+        Lecture lecture = LectureMapper.convertToDomain(lectureRepository.findById(lectureId));
+        if(lecture == null)
+            throw new NoSuchElementException("해당 강의가 존재하지 않습니다.");
+        if(!lecture.isEnrollmentStarted())
+            throw new RegistrationNotOpenException("강의 신청 가능 시간이 아닙니다.");
+        if(lecture.isCapacityExceeded())
+            throw new CapacityExceededException("수용가능한 인원을 초과하였습니다.");
+        LectureApplication lectureApplication = loadLectureApplication(lectureId, userId);
+        if(!Objects.isNull(lectureApplication))
+            throw new IllegalArgumentException("이미 신청한 강의입니다.");
+        lecture.apply();
+        lectureRepository.update(LectureMapper.convertToEntity(lecture));
+        log.info("Applying lecture capacity {}, headCount {}", lecture.getCapacity(), lecture.getHeadCount());
+        lectureApplicationCreate(lectureId, userId);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public boolean isApplyComplete(long lectureId, String userId) {
+        LectureApplication lectureApplication = loadLectureApplication(lectureId, userId);
+        return !Objects.isNull(lectureApplication);
+    }
+
+    private LectureApplication loadLectureApplication(long lectureId, String userId) {
+        //
+        return LectureApplicationMapper.convertToDomain(lectureApplicationRepository.findById(LectureApplication.genId(lectureId, userId)));
+    }
+
+    private void lectureApplicationCreate(long lectureId, String userId) {
+        LectureApplication lectureApplication = LectureApplication.newApplication(lectureId, userId);
+        this.lectureApplicationRepository.create(LectureApplicationMapper.convertToEntity(lectureApplication));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Lecture loadLecture(long lectureId) {
+        //
+        return LectureMapper.convertToDomain(this.lectureRepository.findById(lectureId));
+    }
+
+    /**
+     * 이미 신청한 특강은 목록에 보여주지 않습니다.
+     * @param userId 유저아이디
+     * @return 특강 목록
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public List<Lecture> loadLectures(String userId) {
+        //
+        List<Lecture> lectures = this.lectureRepository.findAll().stream().map(LectureMapper::convertToDomain).toList();
+        Map<Long, List<LectureApplication>> longLectureApplicationMap = this.lectureApplicationRepository.findByUserId(userId).stream().map(LectureApplicationMapper::convertToDomain).collect(Collectors.groupingBy(res->res.getLectureId()));
+        if(Strings.isNotEmpty(userId) || Strings.isNotBlank(userId)) {
+            return lectures.stream().filter(lecture->longLectureApplicationMap.getOrDefault(lecture.getId(), null ) == null).toList();
+        }
+        return lectures;
+    }
+}

--- a/src/main/java/com/hhpluslecture/lecture/service/mapper/LectureMapper.java
+++ b/src/main/java/com/hhpluslecture/lecture/service/mapper/LectureMapper.java
@@ -1,0 +1,35 @@
+package com.hhpluslecture.lecture.service.mapper;
+
+import com.hhpluslecture.lecture.aggregate.domain.Lecture;
+import com.hhpluslecture.lecture.aggregate.entity.LectureEntity;
+
+import java.util.Objects;
+
+public class LectureMapper {
+
+    public static Lecture convertToDomain(LectureEntity lectureEntity) {
+        if(Objects.isNull(lectureEntity)) return null;
+        Lecture lecture = new Lecture();
+        lecture.setId(lectureEntity.getId());
+        lecture.setTitle(lectureEntity.getTitle());
+        lecture.setVersion(lectureEntity.getVersion());
+        lecture.setHeadCount(lectureEntity.getHeadCount());
+        lecture.setCapacity(lectureEntity.getCapacity());
+        lecture.setStartAt(lectureEntity.getStartAt());
+        lecture.setCreateAt(lectureEntity.getCreateAt());
+        return lecture;
+    }
+
+    public static LectureEntity convertToEntity(Lecture lecture) {
+        if(Objects.isNull(lecture)) return null;
+        LectureEntity entity = new LectureEntity();
+            entity.setId(lecture.getId());
+            entity.setTitle(lecture.getTitle());
+            entity.setVersion(lecture.getVersion());
+            entity.setHeadCount(lecture.getHeadCount());
+            entity.setCapacity(lecture.getCapacity());
+            entity.setStartAt(lecture.getStartAt());
+            entity.setCreateAt(lecture.getCreateAt());
+        return entity;
+    }
+}

--- a/src/main/java/com/hhpluslecture/lecture/service/mapper/LectureMapper.java
+++ b/src/main/java/com/hhpluslecture/lecture/service/mapper/LectureMapper.java
@@ -12,7 +12,6 @@ public class LectureMapper {
         Lecture lecture = new Lecture();
         lecture.setId(lectureEntity.getId());
         lecture.setTitle(lectureEntity.getTitle());
-        lecture.setVersion(lectureEntity.getVersion());
         lecture.setHeadCount(lectureEntity.getHeadCount());
         lecture.setCapacity(lectureEntity.getCapacity());
         lecture.setStartAt(lectureEntity.getStartAt());
@@ -25,7 +24,6 @@ public class LectureMapper {
         LectureEntity entity = new LectureEntity();
             entity.setId(lecture.getId());
             entity.setTitle(lecture.getTitle());
-            entity.setVersion(lecture.getVersion());
             entity.setHeadCount(lecture.getHeadCount());
             entity.setCapacity(lecture.getCapacity());
             entity.setStartAt(lecture.getStartAt());

--- a/src/main/java/com/hhpluslecture/lectureApplication/aggregate/domain/LectureApplication.java
+++ b/src/main/java/com/hhpluslecture/lectureApplication/aggregate/domain/LectureApplication.java
@@ -1,0 +1,34 @@
+package com.hhpluslecture.lectureApplication.aggregate.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class LectureApplication {
+    private String id;
+    private String userId;
+    private long lectureId;
+    private LocalDateTime createAt;
+
+    public static LectureApplication newApplication(long lectureId, String userId) {
+        return new LectureApplication(
+                genId(lectureId, userId),
+                userId,
+                lectureId,
+                LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+        );
+    }
+
+    public static String genId(long lectureId, String userId) {
+        //
+        return String.format("%s|%s", lectureId, userId);
+    }
+}

--- a/src/main/java/com/hhpluslecture/lectureApplication/aggregate/dto/LectureApplicationInfo.java
+++ b/src/main/java/com/hhpluslecture/lectureApplication/aggregate/dto/LectureApplicationInfo.java
@@ -1,0 +1,25 @@
+package com.hhpluslecture.lectureApplication.aggregate.dto;
+
+import com.hhpluslecture.lectureApplication.aggregate.domain.LectureApplication;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LectureApplicationInfo {
+    private String userId;
+    private long lectureId;
+    private LocalDateTime createAt;
+
+    public static LectureApplicationInfo from(LectureApplication lectureApplication) {
+        return LectureApplicationInfo.builder()
+                .userId(lectureApplication.getUserId())
+                .lectureId(lectureApplication.getLectureId())
+                .createAt(lectureApplication.getCreateAt())
+                .build();
+    }
+}

--- a/src/main/java/com/hhpluslecture/lectureApplication/aggregate/entity/LectureApplicationEntity.java
+++ b/src/main/java/com/hhpluslecture/lectureApplication/aggregate/entity/LectureApplicationEntity.java
@@ -1,0 +1,26 @@
+package com.hhpluslecture.lectureApplication.aggregate.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name="lecture_application")
+@AllArgsConstructor
+@NoArgsConstructor
+public class LectureApplicationEntity {
+    @Id
+    private String id;
+    private String userId;
+    private long lectureId;
+
+    private LocalDateTime createAt;
+}

--- a/src/main/java/com/hhpluslecture/lectureApplication/repository/LectureApplicationRepository.java
+++ b/src/main/java/com/hhpluslecture/lectureApplication/repository/LectureApplicationRepository.java
@@ -1,0 +1,11 @@
+package com.hhpluslecture.lectureApplication.repository;
+
+import com.hhpluslecture.lectureApplication.aggregate.entity.LectureApplicationEntity;
+
+import java.util.List;
+
+public interface LectureApplicationRepository {
+    String create(LectureApplicationEntity lectureApplicationEntity);
+    LectureApplicationEntity findById(String lectureApplicationId);
+    List<LectureApplicationEntity> findByUserId(String userId);
+}

--- a/src/main/java/com/hhpluslecture/lectureApplication/repository/impl/LectureApplicationRepositoryImpl.java
+++ b/src/main/java/com/hhpluslecture/lectureApplication/repository/impl/LectureApplicationRepositoryImpl.java
@@ -1,0 +1,33 @@
+package com.hhpluslecture.lectureApplication.repository.impl;
+
+import com.hhpluslecture.lectureApplication.aggregate.entity.LectureApplicationEntity;
+import com.hhpluslecture.lectureApplication.repository.LectureApplicationRepository;
+import com.hhpluslecture.lectureApplication.repository.orm.LectureApplicationJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class LectureApplicationRepositoryImpl implements LectureApplicationRepository {
+    //
+    private final LectureApplicationJpaRepository lectureApplicationJpaRepository;
+
+    @Override
+    public String create(LectureApplicationEntity lectureApplicationEntity) {
+        lectureApplicationJpaRepository.save(lectureApplicationEntity);
+        return lectureApplicationEntity.getId();
+    }
+    @Override
+    public LectureApplicationEntity findById(String lectureApplicationId) {
+        Optional<LectureApplicationEntity> application =  lectureApplicationJpaRepository.findById(lectureApplicationId);
+        return application.orElse(null);
+    }
+
+    @Override
+    public List<LectureApplicationEntity> findByUserId(String userId) {
+        return  lectureApplicationJpaRepository.findAllByUserId(userId);
+    }
+}

--- a/src/main/java/com/hhpluslecture/lectureApplication/repository/orm/LectureApplicationJpaRepository.java
+++ b/src/main/java/com/hhpluslecture/lectureApplication/repository/orm/LectureApplicationJpaRepository.java
@@ -1,0 +1,10 @@
+package com.hhpluslecture.lectureApplication.repository.orm;
+
+import com.hhpluslecture.lectureApplication.aggregate.entity.LectureApplicationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface LectureApplicationJpaRepository extends JpaRepository<LectureApplicationEntity, String> {
+    List<LectureApplicationEntity> findAllByUserId(String userId);
+}

--- a/src/main/java/com/hhpluslecture/lectureApplication/service/mapper/LectureApplicationMapper.java
+++ b/src/main/java/com/hhpluslecture/lectureApplication/service/mapper/LectureApplicationMapper.java
@@ -1,0 +1,29 @@
+package com.hhpluslecture.lectureApplication.service.mapper;
+
+import com.hhpluslecture.lectureApplication.aggregate.domain.LectureApplication;
+import com.hhpluslecture.lectureApplication.aggregate.entity.LectureApplicationEntity;
+
+import java.util.Objects;
+
+public class LectureApplicationMapper {
+
+    public static LectureApplication convertToDomain(LectureApplicationEntity lectureApplicationEntity) {
+        if(Objects.isNull(lectureApplicationEntity)) return null;
+        LectureApplication lectureApplication = new LectureApplication();
+        lectureApplication.setId(lectureApplicationEntity.getId());
+        lectureApplication.setUserId(lectureApplicationEntity.getUserId());
+        lectureApplication.setLectureId(lectureApplicationEntity.getLectureId());
+        lectureApplication.setCreateAt(lectureApplicationEntity.getCreateAt());
+        return lectureApplication;
+    }
+
+    public static LectureApplicationEntity convertToEntity(LectureApplication lectureApplication) {
+        if(Objects.isNull(lectureApplication)) return null;
+        LectureApplicationEntity lectureApplicationEntity = new LectureApplicationEntity();
+        lectureApplicationEntity.setId(lectureApplication.getId());
+        lectureApplicationEntity.setUserId(lectureApplication.getUserId());
+        lectureApplicationEntity.setLectureId(lectureApplication.getLectureId());
+        lectureApplicationEntity.setCreateAt(lectureApplication.getCreateAt());
+        return lectureApplicationEntity;
+    }
+}

--- a/src/test/java/com/hhpluslecture/lecture/service/impl/LectureApplyFailTest.java
+++ b/src/test/java/com/hhpluslecture/lecture/service/impl/LectureApplyFailTest.java
@@ -1,0 +1,82 @@
+package com.hhpluslecture.lecture.service.impl;
+
+
+import com.hhpluslecture.lecture.aggregate.entity.LectureEntity;
+import com.hhpluslecture.lecture.repository.LectureRepository;
+import com.hhpluslecture.lecture.service.error.CapacityExceededException;
+import com.hhpluslecture.lecture.service.error.RegistrationNotOpenException;
+import com.hhpluslecture.lectureApplication.aggregate.entity.LectureApplicationEntity;
+import com.hhpluslecture.lectureApplication.repository.LectureApplicationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class LectureApplyFailTest {
+    //
+    @InjectMocks
+    private LectureServiceImpl lectureServiceimpl;
+
+    @Mock
+    private LectureRepository lectureRepository;
+    @Mock
+    private LectureApplicationRepository lectureApplicationRepository;
+
+    private final int lectureId = 1;
+    private final String userId = "test";
+    private final LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+    private LectureEntity lectureEntity;
+
+    @BeforeEach
+    public void setUp() {
+        lectureEntity = new LectureEntity(
+                 lectureId,
+                 "testTitle",
+                 0,
+                 0,
+                 1,
+                 LocalDateTime.of(2024, 6, 1, 12, 0),
+                 now
+         );
+    }
+
+    @Test
+    @DisplayName("특강신청 - 강의가 시작하지 않은 경우")
+    public void applyLectureNotStarted() {
+        //Given
+        lectureEntity.setStartAt(LocalDateTime.of(2030, 6, 1, 12, 0));
+        when(lectureRepository.findById(lectureId)).thenReturn(lectureEntity);
+        //When-Then
+        assertThrows(RegistrationNotOpenException.class, () -> lectureServiceimpl.applyLecture(lectureId, userId));
+    }
+
+    @Test
+    @DisplayName("특강신청 - 수용가능한 인원을 초과한 경우")
+    public void applyCapacityExceeded() {
+        //Given
+        lectureEntity.setCapacity(0);
+        when(lectureRepository.findById(lectureId)).thenReturn(lectureEntity);
+        //When-Then
+        assertThrows(CapacityExceededException.class, () -> lectureServiceimpl.applyLecture(lectureId, userId));
+    }
+
+    @Test
+    @DisplayName("특강신청 - 강의를 이미 신청한경우")
+    public void applyAlreadyApplied() {
+        //Given
+        when(lectureRepository.findById(lectureId)).thenReturn(lectureEntity);
+        when(lectureApplicationRepository.findById(String.format("%d|%s", lectureId, userId))).thenReturn(new LectureApplicationEntity("", userId, lectureId, LocalDateTime.now()));
+        //When-Then
+        assertThrows(IllegalArgumentException.class, () -> lectureServiceimpl.applyLecture(lectureId, userId));
+    }
+}

--- a/src/test/java/com/hhpluslecture/lecture/service/impl/LectureApplyFailTest.java
+++ b/src/test/java/com/hhpluslecture/lecture/service/impl/LectureApplyFailTest.java
@@ -43,7 +43,6 @@ public class LectureApplyFailTest {
                  lectureId,
                  "testTitle",
                  0,
-                 0,
                  1,
                  LocalDateTime.of(2024, 6, 1, 12, 0),
                  now
@@ -55,7 +54,7 @@ public class LectureApplyFailTest {
     public void applyLectureNotStarted() {
         //Given
         lectureEntity.setStartAt(LocalDateTime.of(2030, 6, 1, 12, 0));
-        when(lectureRepository.findById(lectureId)).thenReturn(lectureEntity);
+        when(lectureRepository.findByIdForUpdate(lectureId)).thenReturn(lectureEntity);
         //When-Then
         assertThrows(RegistrationNotOpenException.class, () -> lectureServiceimpl.applyLecture(lectureId, userId));
     }
@@ -65,7 +64,7 @@ public class LectureApplyFailTest {
     public void applyCapacityExceeded() {
         //Given
         lectureEntity.setCapacity(0);
-        when(lectureRepository.findById(lectureId)).thenReturn(lectureEntity);
+        when(lectureRepository.findByIdForUpdate(lectureId)).thenReturn(lectureEntity);
         //When-Then
         assertThrows(CapacityExceededException.class, () -> lectureServiceimpl.applyLecture(lectureId, userId));
     }
@@ -74,7 +73,7 @@ public class LectureApplyFailTest {
     @DisplayName("특강신청 - 강의를 이미 신청한경우")
     public void applyAlreadyApplied() {
         //Given
-        when(lectureRepository.findById(lectureId)).thenReturn(lectureEntity);
+        when(lectureRepository.findByIdForUpdate(lectureId)).thenReturn(lectureEntity);
         when(lectureApplicationRepository.findById(String.format("%d|%s", lectureId, userId))).thenReturn(new LectureApplicationEntity("", userId, lectureId, LocalDateTime.now()));
         //When-Then
         assertThrows(IllegalArgumentException.class, () -> lectureServiceimpl.applyLecture(lectureId, userId));

--- a/src/test/java/com/hhpluslecture/lecture/service/impl/LectureServiceImplTest.java
+++ b/src/test/java/com/hhpluslecture/lecture/service/impl/LectureServiceImplTest.java
@@ -1,0 +1,113 @@
+package com.hhpluslecture.lecture.service.impl;
+
+import com.hhpluslecture.lecture.aggregate.domain.Lecture;
+import com.hhpluslecture.lecture.service.LectureService;
+import com.hhpluslecture.lecture.service.error.CapacityExceededException;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.Thread.sleep;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@TestPropertySource(locations = "classpath:application-test.yml")
+class LectureServiceImplTest {
+
+    @Autowired
+    private LectureService lectureService;
+
+    private final String title = "test";
+    private final int capacity = 5;
+    private final LocalDateTime startAt = LocalDateTime.of(2024, 6, 1, 12, 0);
+    private long lectureId = 1;
+
+    @Test
+    @Order(1)
+    @DisplayName("정상적으로 특강이 생성되는지 검증")
+    void createLecture() {
+        //Given
+        lectureId = lectureService.createLecture(title, capacity, startAt);
+
+        assertNotEquals(0, lectureId);
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("정상적으로 특강이 신청되는지 검증")
+    void applyLecture() {
+        //When
+        String userId = "1";
+        lectureService.applyLecture(lectureId, userId);
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("정상적으로 특강을 가져오는지 검증")
+    void loadLecture() {
+        //WHEN
+        Lecture lecture = lectureService.loadLecture(lectureId);
+        //THEN
+        assertNotNull(lecture);
+        assertEquals(title, lecture.getTitle());
+        assertEquals(capacity, lecture.getCapacity());
+        assertEquals(startAt, lecture.getStartAt());
+        assertEquals(lectureId, lecture.getId());
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("정상적으로 리스트 조회되는지 검증 - query문 한개만 발행하도록")
+    void loadLectures() {
+        //When
+        List<Lecture> lectures = lectureService.loadLectures("");
+        //Then
+        assertNotNull(lectures);
+        assertNotEquals(0, lectures.size());
+        Lecture lecture = lectures.stream().filter(l -> l.getId() == lectureId).findFirst().orElse(null);
+        assertNotNull(lecture);
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("특강 신청 동시성 테스트")
+    void usePoint() throws InterruptedException {
+        //When
+        int memberCount = 30;
+        ExecutorService executorsService = Executors.newFixedThreadPool(memberCount);
+        CountDownLatch latch = new CountDownLatch(memberCount);
+
+        AtomicInteger successCount = new AtomicInteger();
+        sleep(1000);
+
+        for (int i = 0; i < memberCount; i++) {
+            executorsService.submit(() -> {
+                try {
+                    lectureService.applyLecture(lectureId, UUID.randomUUID().toString());
+                    successCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        //Then
+        assertAll(
+                () -> assertEquals(successCount.get(), 4)
+        );
+    }
+}

--- a/src/test/java/com/hhpluslecture/lecture/service/impl/LectureServiceImplTest.java
+++ b/src/test/java/com/hhpluslecture/lecture/service/impl/LectureServiceImplTest.java
@@ -2,7 +2,6 @@ package com.hhpluslecture.lecture.service.impl;
 
 import com.hhpluslecture.lecture.aggregate.domain.Lecture;
 import com.hhpluslecture.lecture.service.LectureService;
-import com.hhpluslecture.lecture.service.error.CapacityExceededException;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,7 +12,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -86,7 +84,7 @@ class LectureServiceImplTest {
     @DisplayName("특강 신청 동시성 테스트")
     void usePoint() throws InterruptedException {
         //When
-        int memberCount = 30;
+        int memberCount = 6;
         ExecutorService executorsService = Executors.newFixedThreadPool(memberCount);
         CountDownLatch latch = new CountDownLatch(memberCount);
 


### PR DESCRIPTION
# Pull Request 사이즈를 조절하려하다 실패했습니다... 죄송합니다.

코칭시간때 말씀하셨던 데로 아키텍처에 대해 고민을 하는 시간을 가져보았습니다.   
이번 수정내용은 코칭시간 때 보여주신 아키텍처를 적용해보았고(이로인해 변경 파일이 많이 생겼습니다.),    
낙관적 락 (@Version) 을 적용하는 방안으로 수정하였습니다.   
동시성 테스트를 위해 LectureServiceImplTest에서 통합 테스트를 진행하였습니다.   

## 리뷰포인트
- JPA의 영속성 컨텍스트의 영역은 Business Layer에서 관리하는 비즈니스 로직들이 영향을 받으면 의도치 않은 Dirty checking등이 이루어져 Persistence Layer에서만 관리를 하도록 하였는데 이에 대해 어떻게 생각하시는지 튜터님의 의견을 여쭤보고 싶습니다.
- 제가 구성한 디렉토리, 아키텍처에 대해 피드백 받고 싶습니다.
 
